### PR TITLE
update command to remove directory to work cross-os

### DIFF
--- a/libs/lib3/project.json
+++ b/libs/lib3/project.json
@@ -65,14 +65,14 @@
       "configurations": {
         "production": {
           "commands": [
-            "rm -rf dist/libs/lib3",
+            "node -e \"require('fs').rmSync('dist/libs/lib3', {recursive: true, force: true})\"",
             "nx run lib3:build-lib:production"
           ],
           "parallel": false
         },
         "development": {
           "commands": [
-            "rm -rf dist/libs/lib3",
+            "node -e \"require('fs').rmSync('dist/libs/lib3', {recursive: true, force: true})\"",
             "nx run lib3:build-lib:development"
           ],
           "parallel": false

--- a/libs/lib3/project.json
+++ b/libs/lib3/project.json
@@ -65,26 +65,20 @@
       "configurations": {
         "production": {
           "commands": [
-            "nx run lib3:remove-dir --path=dist/libs/lib3",
+            "node tools/scripts/remove-dir.js dist/libs/lib3",
             "nx run lib3:build-lib:production"
           ],
           "parallel": false
         },
         "development": {
           "commands": [
-            "nx run lib3:remove-dir --path=dist/libs/lib3",
+            "node tools/scripts/remove-dir.js dist/libs/lib3",
             "nx run lib3:build-lib:development"
           ],
           "parallel": false
         }
       },
       "defaultConfiguration": "production"
-    },
-    "remove-dir": {
-      "executor": "@nrwl/workspace:run-commands",
-      "options": {
-          "command": "node tools/scripts/remove-dir.js --path {args.path}"
-      }
     },
     "test": {
       "executor": "@nrwl/jest:jest",

--- a/libs/lib3/project.json
+++ b/libs/lib3/project.json
@@ -65,20 +65,26 @@
       "configurations": {
         "production": {
           "commands": [
-            "node -e \"require('fs').rmSync('dist/libs/lib3', {recursive: true, force: true})\"",
+            "nx run lib3:remove-dir --path=dist/libs/lib3",
             "nx run lib3:build-lib:production"
           ],
           "parallel": false
         },
         "development": {
           "commands": [
-            "node -e \"require('fs').rmSync('dist/libs/lib3', {recursive: true, force: true})\"",
+            "nx run lib3:remove-dir --path=dist/libs/lib3",
             "nx run lib3:build-lib:development"
           ],
           "parallel": false
         }
       },
       "defaultConfiguration": "production"
+    },
+    "remove-dir": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+          "command": "node tools/scripts/remove-dir.js --path {args.path}"
+      }
     },
     "test": {
       "executor": "@nrwl/jest:jest",

--- a/tools/scripts/remove-dir.js
+++ b/tools/scripts/remove-dir.js
@@ -1,16 +1,13 @@
-#!/usr/bin/env node
-
 const fs = require('fs');
 
-// @see https://regex101.com/library/vzA46H
-const pattern = new RegExp(/(?<=--path[ |=])dist\/.*(?=$)/);
+const args = process.argv.slice(2);
 
-const argvString = process.argv.join(' ').replace(/["']/g, '');
-
-if(pattern.test(argvString)) {
-    const matched = argvString.match(pattern).pop();
-    fs.rmSync(matched, {recursive: true, force: true});
-} else {
-    console.error("Unable to find a 'path' argument with a value containing 'dist' folder.");
-    process.exit(1);
+if (!args.length) {
+  throw new Error('No path specified. Please specify a path to remove.');
+} else if (args.length > 1) {
+  throw new Error(
+    'Too many arguments. Please specify only one path to remove.'
+  );
 }
+
+fs.rmSync(args[0], { recursive: true, force: true });

--- a/tools/scripts/remove-dir.js
+++ b/tools/scripts/remove-dir.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+// @see https://regex101.com/library/vzA46H
+const pattern = new RegExp(/(?<=--path[ |=])dist\/.*(?=$)/);
+
+const argvString = process.argv.join(' ').replace(/["']/g, '');
+
+if(pattern.test(argvString)) {
+    const matched = argvString.match(pattern).pop();
+    fs.rmSync(matched, {recursive: true, force: true});
+} else {
+    console.error("Unable to find a 'path' argument with a value containing 'dist' folder.");
+    process.exit(1);
+}


### PR DESCRIPTION
The command `rm` seems to not be available for Windows users by default. This PR changes the 2 `rm` expression occurrences to use node's equivalent, `rmSync`.  

Below is node's doc mentioning about this command:

> Synchronously removes files and directories (modeled on the standard POSIX rm utility). Returns undefined. -[src](https://nodejs.org/api/fs.html#fsrmsyncpath-options)