### PR TITLE
fix app spec tests

### DIFF
--- a/apps/app1/src/app/app.component.spec.ts
+++ b/apps/app1/src/app/app.component.spec.ts
@@ -1,3 +1,5 @@
+import { Lib1Module } from '@angular-tailwind-nx/lib1';
+import { Lib2Module } from '@angular-tailwind-nx/lib2';
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { NxWelcomeComponent } from './nx-welcome.component';
@@ -6,6 +8,7 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [AppComponent, NxWelcomeComponent],
+      imports: [Lib1Module, Lib2Module],
     }).compileComponents();
   });
 
@@ -25,6 +28,6 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Welcome app1');
+    expect(compiled.querySelector('header')?.textContent).toContain('Tailwind CSS');
   });
 });

--- a/apps/app2/src/app/app.component.spec.ts
+++ b/apps/app2/src/app/app.component.spec.ts
@@ -1,3 +1,5 @@
+import { Lib1Module } from '@angular-tailwind-nx/lib1';
+import { Lib2Module } from '@angular-tailwind-nx/lib2';
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { NxWelcomeComponent } from './nx-welcome.component';
@@ -6,6 +8,7 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [AppComponent, NxWelcomeComponent],
+      imports: [Lib1Module, Lib2Module]
     }).compileComponents();
   });
 
@@ -25,6 +28,6 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Welcome app2');
+    expect(compiled.querySelector('header')?.textContent).toContain('Tailwind CSS');
   });
 });


### PR DESCRIPTION
Spec files for 'app1' and 'app2' prevented tests to run due to unknown components on the DOM. This was fixed by adding `imports` with the name of the Angular module these unknown components belonged to. 

Also, in the same files, tests were expecting a test fixture with a value of 'Welcome app1', which seems to be from the Nx welcome component. This PR updates both spec files, expecting a value of 'Tailwind CSS' to be on the DOM for each app. This value is set in the HeaderComponent's template. 